### PR TITLE
add pip check to tests

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
     folder: conda-store-server
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - name: conda-store
@@ -46,9 +46,12 @@ outputs:
         - {{ pin_subpackage('conda-store-server', min_pin='x.x.x', max_pin='x.x.x') }}
 
     test:
+      requires:
+        - pip
       imports:
         - conda_store
       commands:
+        - pip check
         - conda-store --help
 
   - name: conda-store-server
@@ -99,9 +102,12 @@ outputs:
         - {{ pin_subpackage('conda-store', min_pin='x.x.x', max_pin='x.x.x') }}
 
     test:
+      requires:
+        - pip
       imports:
         - conda_store_server
       commands:
+        - pip check
         - conda-store-server --help
         - conda-store-worker --help
 


### PR DESCRIPTION
To make sure dependencies are satisfied. The test currently fails with:

```
conda-store 2024.11.2 requires jupyter-launcher-shortcuts, which is not installed.
conda-store 2024.11.2 requires jupyterhub, which is not installed.
conda-store 2024.11.2 requires jupyterlab, which is not installed.
conda-store 2024.11.2 requires jupyterlab-conda-store, which is not installed.
```

it's unclear to me if the fix is to remove these packages from requirements upstream and make a fresh release (related: https://github.com/conda-incubator/conda-store/issues/1053) or add them here, so conda-store depends on jupyterlab, jupyterhub, etc. as it does with pip.